### PR TITLE
Cold cache handling

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    jason-rails (0.7.1)
+    jason-rails (0.7.5)
       connection_pool (>= 2.2.3)
       jsondiff
       rails (>= 5)

--- a/lib/jason/lua_generator.rb
+++ b/lib/jason/lua_generator.rb
@@ -1,10 +1,13 @@
 class Jason::LuaGenerator
   ## TODO load these scripts and evalsha
   def cache_json(model_name, id, payload)
+    expiry = 7*24*60*60 + rand(6*60*60)
+
+    # ensure the content expires first
     cmd = <<~LUA
       local gidx = redis.call('INCR', 'jason:gidx')
-      redis.call( 'set', 'jason:cache:' .. ARGV[1] .. ':' .. ARGV[2] .. ':gidx', gidx )
-      redis.call( 'set', 'jason:cache:' .. ARGV[1] .. ':' .. ARGV[2], ARGV[3] )
+      redis.call( 'setex', 'jason:cache:' .. ARGV[1] .. ':' .. ARGV[2] .. ':gidx', #{expiry}, gidx )
+      redis.call( 'setex', 'jason:cache:' .. ARGV[1] .. ':' .. ARGV[2], #{expiry - 60}, ARGV[3] )
       return gidx
     LUA
 

--- a/lib/jason/lua_generator.rb
+++ b/lib/jason/lua_generator.rb
@@ -4,7 +4,7 @@ class Jason::LuaGenerator
     cmd = <<~LUA
       local gidx = redis.call('INCR', 'jason:gidx')
       redis.call( 'set', 'jason:cache:' .. ARGV[1] .. ':' .. ARGV[2] .. ':gidx', gidx )
-      redis.call( 'hset', 'jason:cache:' .. ARGV[1], ARGV[2], ARGV[3] )
+      redis.call( 'set', 'jason:cache:' .. ARGV[1] .. ':' .. ARGV[2], ARGV[3] )
       return gidx
     LUA
 
@@ -15,15 +15,26 @@ class Jason::LuaGenerator
     # If value has changed, return old value and new idx. Otherwise do nothing.
     cmd = <<~LUA
       local t = {}
-      local models = {}
+      local insts = {}
+      local miss_ids = {}
       local ids = redis.call('smembers', 'jason:subscriptions:' .. ARGV[2] .. ':ids:' .. ARGV[1])
 
       for k,id in pairs(ids) do
-        models[#models+1] = redis.call( 'hget', 'jason:cache:' .. ARGV[1], id)
+        local result = redis.call( 'get', 'jason:cache:' .. ARGV[1] .. ':' .. id)
+        if (result == false) then
+          miss_ids[#miss_ids+1] = id
+        else
+          insts[#insts+1] = result
+        end
       end
 
-      t[#t+1] = models
-      t[#t+1] = redis.call( 'get', 'jason:subscription:' .. ARGV[2] .. ':' .. ARGV[1] .. ':idx' )
+      if next(miss_ids) == nil then
+        t[#t+1] = insts
+        t[#t+1] = redis.call( 'get', 'jason:subscription:' .. ARGV[2] .. ':' .. ARGV[1] .. ':idx' )
+      else
+        t[#t+1] = miss_ids
+        t[#t+1] = 'missing'
+      end
 
       return t
     LUA

--- a/lib/jason/publisher.rb
+++ b/lib/jason/publisher.rb
@@ -124,12 +124,16 @@ module Jason::Publisher
   end
 
   def jason_cached_value
-    JSON.parse($redis_jason.hget("jason:cache:#{self.class.name.underscore}", id) || '{}')
+    JSON.parse($redis_jason.get("jason:cache:#{self.class.name.underscore}:#{id}") || '{}')
   end
 
   class_methods do
     def cache_all
       all.find_each(&:cache_json)
+    end
+
+    def cache_for(ids)
+      where(id: ids).find_each(&:cache_json)
     end
 
     def has_jason?


### PR DESCRIPTION
Sometimes the dataset that Jason is used for can grow larger than is reasonable to hold in Redis indefinitely. This changes Jason to set an expiry on cache data, and to handle cold cache gracefully (albeit with more database queries).